### PR TITLE
feat: show streak count as PWA app icon badge

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1789,6 +1789,16 @@ export default function App() {
     localStorage.setItem('azureAITrainer', JSON.stringify(userData))
   }, [userData])
 
+  useEffect(() => {
+    if ('setAppBadge' in navigator) {
+      if (userData.streak > 0) {
+        navigator.setAppBadge(userData.streak).catch(() => {})
+      } else {
+        navigator.clearAppBadge().catch(() => {})
+      }
+    }
+  }, [userData.streak])
+
   function handleStartLesson(moduleId, lessonIndex) {
     const mod = modules.find(m => m.id === moduleId)
     setActiveLesson({ mod, lessonIndex })


### PR DESCRIPTION
Uses the Web App Badging API (navigator.setAppBadge) to display the current streak count as a native badge on the installed PWA icon. Clears the badge when streak is 0. Gracefully degrades on unsupported browsers.

Closes #19

Generated with [Claude Code](https://claude.ai/code)