### PR TITLE
feat: add missing AI-102 content (Face Service & NLP Summarization)

### DIFF
--- a/src/modules/module4.js
+++ b/src/modules/module4.js
@@ -140,6 +140,90 @@ export default {
       ]
     },
     {
+      title: "Azure AI Face Service",
+      questions: [
+        {
+          question: "A security system needs to determine whether a face captured by a camera belongs to one of 200 registered employees. Which Azure AI Face operation enables this?",
+          answers: [
+            "Face detection — returns bounding boxes and face IDs only",
+            "Face identification — matches a detected face against a PersonGroup of known people",
+            "Face verification — performs a 1:1 comparison between two specific face images",
+            "Face grouping — clusters visually similar faces together"
+          ],
+          correct: 1,
+          explanation: "Face identification performs a 1:N comparison, matching a detected face against all persons enrolled in a PersonGroup (or LargePersonGroup) and returning the most likely match with a confidence score. Verification is 1:1; identification is 1:N."
+        },
+        {
+          question: "What is liveness detection in Azure AI Face, and why is it important for authentication scenarios?",
+          answers: [
+            "It checks whether the image resolution is sufficient for accurate recognition",
+            "It determines whether the face is from a real person physically present rather than a photo, video, or mask replay",
+            "It validates that the Azure Face endpoint is reachable before processing requests",
+            "It confirms that the detected face matches a live record in the enrolled database"
+          ],
+          correct: 1,
+          explanation: "Liveness detection (anti-spoofing) verifies that the face captured is from a live person physically present — not a photograph, video replay, or synthetic mask. It is a critical security layer for face-based authentication to prevent presentation attacks."
+        },
+        {
+          question: "A developer calls the Azure AI Face Detect API and wants to determine whether the detected person is wearing glasses. What must they include in the API request?",
+          answers: [
+            "The returnFaceId parameter set to true",
+            "The returnFaceAttributes parameter specifying 'glasses' (and any other desired attributes)",
+            "A separate call to a dedicated FaceAttribute API after detection",
+            "A custom vision model trained on eyewear classification"
+          ],
+          correct: 1,
+          explanation: "The Face Detect API only returns face attributes when you explicitly request them via the returnFaceAttributes parameter. Supported attributes include glasses, age estimation, head pose, blur, exposure, occlusion, and mask. Without this parameter, only bounding box and optional face IDs are returned."
+        },
+        {
+          question: "An e-commerce site wants to verify that a selfie taken during login matches the ID photo submitted during account registration. Which Azure AI Face operation performs this 1:1 comparison?",
+          answers: [
+            "Face identification against a PersonGroup containing the user's enrolled face",
+            "Face verification, which compares two face images and returns whether they depict the same person",
+            "Liveness detection, which confirms the selfie is from a real person",
+            "Face grouping, which clusters similar faces to find a match"
+          ],
+          correct: 1,
+          explanation: "Face verification performs a 1:1 comparison between two face images and returns a confidence score indicating whether they depict the same individual. For comparing a selfie against a specific stored ID photo, verification is the correct and most efficient operation."
+        }
+      ],
+      variantQuestions: [
+        {
+          question: "A hotel check-in kiosk uses Azure AI Face to recognize VIP guests. An attacker attempts to authenticate using a printed photograph of a VIP. Which Azure AI Face capability is designed to prevent this attack?",
+          answers: [
+            "Face identification with a high confidence threshold to reject low-confidence matches",
+            "Liveness detection, which determines whether the face is from a real live person or a presentation attack",
+            "Face verification comparing the photo against the enrolled face ID",
+            "returnFaceAttributes with blur and exposure checks to reject low-quality images"
+          ],
+          correct: 1,
+          explanation: "Liveness detection detects presentation attacks such as printed photographs, video replays, and masks. It verifies that the face comes from a physically present live person — a check that confidence thresholds or quality filters cannot provide."
+        },
+        {
+          question: "You have enrolled 500 employees into a PersonGroup and trained it. You now need to confirm whether a captured face belongs specifically to employee ID 42, without checking all other employees. Which Face API operation is most efficient?",
+          answers: [
+            "Face identification against the full PersonGroup — it returns the best match automatically",
+            "Face verification between the captured face and a stored face from employee 42's enrollment",
+            "Face grouping to cluster the captured face with similar faces in the PersonGroup",
+            "Face detection with returnFaceAttributes to compare metadata with employee 42's profile"
+          ],
+          correct: 1,
+          explanation: "Face verification performs a direct 1:1 comparison between a captured face and a specific known face. When you already know which person to check against, verification is more targeted and efficient than identification, which evaluates all persons in the group."
+        },
+        {
+          question: "After calling the Azure AI Face Detect API, the response contains a 'faceId' but no attribute data such as age or glasses. What is the most likely reason?",
+          answers: [
+            "The image was too small for attribute analysis",
+            "The returnFaceAttributes parameter was not specified in the request",
+            "Attribute detection requires a separate Face Analyze API call",
+            "Attribute data is only available in the Azure Government cloud region"
+          ],
+          correct: 1,
+          explanation: "Face attributes (age, glasses, emotion, head pose, blur, etc.) are only returned when you explicitly include the returnFaceAttributes parameter in the Detect request. Without it, the API returns only bounding boxes and face IDs."
+        }
+      ]
+    },
+    {
       title: "Video Analysis",
       questions: [
         {

--- a/src/modules/module5.js
+++ b/src/modules/module5.js
@@ -67,6 +67,90 @@ export default {
       ]
     },
     {
+      title: "Text Summarization and Entity Linking",
+      questions: [
+        {
+          question: "Which Azure AI Language feature produces a shorter version of a document by selecting and returning the most important sentences verbatim from the original text?",
+          answers: [
+            "Abstractive summarization",
+            "Extractive summarization",
+            "Key phrase extraction",
+            "Named entity recognition"
+          ],
+          correct: 1,
+          explanation: "Extractive summarization identifies and returns the most informative sentences directly from the source document. The summary is composed of verbatim sentences extracted from the original text. Abstractive summarization instead generates new sentences in the model's own words."
+        },
+        {
+          question: "A developer needs to summarize lengthy meeting transcripts into concise prose paragraphs written in the service's own words, not quoting the transcript verbatim. Which Azure AI Language summarization type should they use?",
+          answers: [
+            "Extractive summarization — selects key sentences from the source",
+            "Abstractive summarization — generates new sentences synthesizing the key information",
+            "Key phrase extraction — returns important terms and phrases",
+            "Sentiment analysis — identifies the overall tone of the transcript"
+          ],
+          correct: 1,
+          explanation: "Abstractive summarization generates a concise summary in new, natural-sounding sentences, synthesizing key information from the source rather than extracting verbatim sentences. This produces more readable, prose-style summaries compared to extractive summarization."
+        },
+        {
+          question: "Azure AI Language entity linking serves which purpose beyond what standard Named Entity Recognition (NER) provides?",
+          answers: [
+            "Detecting PII entities such as names and phone numbers for redaction",
+            "Disambiguating recognized entity mentions and linking them to their corresponding entries in a knowledge base such as Wikipedia",
+            "Classifying entities by broader categories such as Person, Organization, or Location",
+            "Extracting named entities from speech audio rather than text"
+          ],
+          correct: 1,
+          explanation: "Entity linking goes beyond NER by disambiguating which specific real-world entity a mention refers to and providing a link to an authoritative knowledge base (e.g., Wikipedia). For example, 'Apple' is disambiguated as the technology company vs. the fruit, with a URL to the correct knowledge base entry."
+        },
+        {
+          question: "What is the key functional difference between Named Entity Recognition (NER) and Entity Linking in Azure AI Language?",
+          answers: [
+            "NER processes text; entity linking processes images and documents",
+            "NER identifies and categorizes entity mentions in text; entity linking additionally disambiguates them and provides knowledge base reference links",
+            "Entity linking is a subset of NER used exclusively for organization entities",
+            "NER works without internet access; entity linking requires a live connection to Wikipedia"
+          ],
+          correct: 1,
+          explanation: "NER identifies spans of text as entity categories (Person, Location, Organization, Date, etc.). Entity linking adds disambiguation — determining which specific real-world entity is meant — and returns a URL to the corresponding knowledge base entry. They are complementary capabilities."
+        }
+      ],
+      variantQuestions: [
+        {
+          question: "A news summarization service needs to condense articles into 3–4 new sentences capturing the main points, without copying text directly from the article. Which Azure AI Language feature should be used?",
+          answers: [
+            "Extractive summarization — returns selected original sentences from the article",
+            "Abstractive summarization — generates new sentences synthesizing the key information",
+            "Key phrase extraction — returns important keywords and phrases, not full sentences",
+            "Sentiment analysis — evaluates article tone but does not produce a summary"
+          ],
+          correct: 1,
+          explanation: "Abstractive summarization generates summary content in the service's own words, producing naturally-written prose rather than copying verbatim sentences. For new, synthesized summary sentences, abstractive is the correct choice."
+        },
+        {
+          question: "A legal document contains the phrase 'filed a claim against Mercury'. Azure AI Language NER labels 'Mercury' as an Organization entity. Entity Linking returns a Wikipedia URL for Mercury Insurance Group. What does this demonstrate about the two features working together?",
+          answers: [
+            "NER detected the entity category; entity linking resolved the ambiguity by identifying the specific real-world organization",
+            "NER and entity linking produced conflicting results and the ambiguous entity should be discarded",
+            "Entity linking replaced NER in this pipeline to reduce API calls and processing time",
+            "The entity linking URL indicates the document was sourced from Wikipedia"
+          ],
+          correct: 0,
+          explanation: "NER identifies the text span 'Mercury' as an Organization entity category. Entity linking then disambiguates which specific Mercury is referenced and links to the correct knowledge base entry (Mercury Insurance Group, not the planet or car brand). They are complementary, not conflicting."
+        },
+        {
+          question: "A developer uses Azure AI Language extractive summarization on a 10-page report and receives back 5 sentences. What is guaranteed to be true about those 5 sentences?",
+          answers: [
+            "They are newly generated sentences that paraphrase the report's key points",
+            "They are verbatim sentences taken directly from the original report, selected as most important",
+            "They are the first 5 sentences of the report with filler words removed",
+            "They are translated into a neutral English register for broader accessibility"
+          ],
+          correct: 1,
+          explanation: "Extractive summarization returns sentences that are copied verbatim from the source document — they are not paraphrased or rewritten. The service scores and selects the sentences judged most informative, but the wording is unchanged from the original."
+        }
+      ]
+    },
+    {
       title: "Translation with Azure AI Translator",
       questions: [
         {


### PR DESCRIPTION
Adds two missing lessons identified in issue #26:

- **Module 4: Azure AI Face Service** — face detection, identification, verification, liveness detection, and attributes
- **Module 5: Text Summarization & Entity Linking** — extractive vs abstractive summarization and entity linking with knowledge base disambiguation

Both topics are explicitly tested in the AI-102 exam.

Closes #26

Generated with [Claude Code](https://claude.ai/code)