### PR TITLE
feat: add case study lessons and text-input question format

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -492,6 +492,104 @@ body {
   color: white;
 }
 
+.vp-case-study {
+  background: #e8f4fd;
+  border-color: #0d6efd;
+  color: #0d6efd;
+  font-size: 18px;
+}
+
+.vp-case-study.vp-completed {
+  background: #28a745;
+  border-color: #1e7e34;
+  color: white;
+}
+
+/* ─── Case Study Scenario Card ──────────────────────────── */
+
+.scenario-card {
+  background: #f0f7ff;
+  border: 2px solid #0d6efd;
+  border-radius: 12px;
+  padding: 16px 20px;
+  margin-bottom: 20px;
+}
+
+.scenario-toggle {
+  background: none;
+  border: none;
+  font-size: 14px;
+  font-weight: 700;
+  color: #0d6efd;
+  cursor: pointer;
+  padding: 0;
+  margin-bottom: 8px;
+}
+
+.scenario-toggle:hover {
+  text-decoration: underline;
+}
+
+.scenario-text {
+  font-size: 14px;
+  color: #2c3e50;
+  line-height: 1.7;
+  white-space: pre-line;
+}
+
+/* ─── Text Input Question Type ──────────────────────────── */
+
+.question-type-badge {
+  display: inline-block;
+  background: #e7f3ff;
+  color: #0066cc;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: 12px;
+  margin-bottom: 12px;
+}
+
+.text-input-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.text-answer-input {
+  width: 100%;
+  padding: 14px 18px;
+  font-size: 16px;
+  border: 2px solid #dee2e6;
+  border-radius: 12px;
+  outline: none;
+  transition: border-color 0.2s ease;
+  font-family: inherit;
+}
+
+.text-answer-input:focus {
+  border-color: #667eea;
+}
+
+.text-answer-input.correct {
+  border-color: #28a745;
+  background: #d4edda;
+}
+
+.text-answer-input.incorrect {
+  border-color: #dc3545;
+  background: #f8d7da;
+}
+
+.text-correct-answer {
+  font-size: 14px;
+  font-weight: 600;
+  color: #155724;
+  background: #d4edda;
+  padding: 8px 14px;
+  border-radius: 8px;
+}
+
 .vp-connector {
   width: 3px;
   flex-shrink: 0;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -125,8 +125,8 @@ function LessonPath({ userData, onStartLesson }) {
               onClick={() => !node.isLocked && onStartLesson(node.mod.id, node.lessonIndex)}
             >
               <div className="vp-node-col">
-                <div className={`vp-node vp-lesson-node ${node.isCompleted ? 'vp-completed' : node.isLocked ? 'vp-locked' : 'vp-available'}${node.lesson.isRevision ? ' vp-revision' : ''}`}>
-                  {node.isCompleted ? '✓' : node.lesson.isRevision ? '🔄' : node.lessonIndex + 1}
+                <div className={`vp-node vp-lesson-node ${node.isCompleted ? 'vp-completed' : node.isLocked ? 'vp-locked' : 'vp-available'}${node.lesson.isRevision ? ' vp-revision' : node.lesson.isCaseStudy ? ' vp-case-study' : ''}`}>
+                  {node.isCompleted ? '✓' : node.lesson.isRevision ? '🔄' : node.lesson.isCaseStudy ? '📋' : node.lessonIndex + 1}
                 </div>
                 {!isLast && <div className={`vp-connector ${node.isCompleted ? 'vp-connector-done' : ''}`} />}
               </div>
@@ -148,13 +148,14 @@ function QuizView({ mod, lesson, onComplete, onBack }) {
   // questions + variantQuestions each time the lesson is started, so users
   // see different questions and in a different order on every attempt.
   const [questionQueue, setQuestionQueue] = useState(() => {
-    if (lesson.isRevision) return lesson.questions
+    if (lesson.isRevision || lesson.isCaseStudy) return lesson.questions
     const pool = [...lesson.questions, ...(lesson.variantQuestions || [])]
     const shuffled = shuffleArray(pool)
     return shuffled.slice(0, lesson.questions.length)
   })
   const [questionIndex, setQuestionIndex] = useState(0)
   const [selectedAnswer, setSelectedAnswer] = useState(null)
+  const [textInputValue, setTextInputValue] = useState('')
   const [answered, setAnswered] = useState(false)
   const [incorrectQuestions, setIncorrectQuestions] = useState([])
   const [roundNumber, setRoundNumber] = useState(1)
@@ -162,8 +163,12 @@ function QuizView({ mod, lesson, onComplete, onBack }) {
   const [retryQueue, setRetryQueue] = useState([])
   const [showResult, setShowResult] = useState(false)
   const [xpGained, setXpGained] = useState(0)
+  const [scenarioCollapsed, setScenarioCollapsed] = useState(false)
 
   const question = questionQueue[questionIndex]
+  const isTextInput = question.type === 'text-input'
+  const isTextCorrect = answered && isTextInput &&
+    question.acceptedAnswers.some(a => a.toLowerCase() === textInputValue.trim().toLowerCase())
 
   function handleSelectAnswer(index) {
     if (answered) return
@@ -171,10 +176,20 @@ function QuizView({ mod, lesson, onComplete, onBack }) {
   }
 
   function handleCheckAnswer() {
-    if (selectedAnswer === null) return
-    setAnswered(true)
-    if (selectedAnswer !== question.correct) {
-      setIncorrectQuestions(prev => [...prev, question])
+    if (isTextInput) {
+      if (textInputValue.trim() === '') return
+      setAnswered(true)
+      const normalized = textInputValue.trim().toLowerCase()
+      const correct = question.acceptedAnswers.some(a => a.toLowerCase() === normalized)
+      if (!correct) {
+        setIncorrectQuestions(prev => [...prev, question])
+      }
+    } else {
+      if (selectedAnswer === null) return
+      setAnswered(true)
+      if (selectedAnswer !== question.correct) {
+        setIncorrectQuestions(prev => [...prev, question])
+      }
     }
   }
 
@@ -182,7 +197,9 @@ function QuizView({ mod, lesson, onComplete, onBack }) {
     if (questionIndex + 1 < questionQueue.length) {
       setQuestionIndex(i => i + 1)
       setSelectedAnswer(null)
+      setTextInputValue('')
       setAnswered(false)
+      setScenarioCollapsed(true)
       return
     }
 
@@ -204,11 +221,13 @@ function QuizView({ mod, lesson, onComplete, onBack }) {
     setQuestionQueue(retryQueue)
     setQuestionIndex(0)
     setSelectedAnswer(null)
+    setTextInputValue('')
     setAnswered(false)
     setIncorrectQuestions([])
     setRoundNumber(r => r + 1)
     setShowRoundSummary(false)
     setRetryQueue([])
+    setScenarioCollapsed(false)
   }
 
   function getAnswerClass(index) {
@@ -221,6 +240,8 @@ function QuizView({ mod, lesson, onComplete, onBack }) {
     }
     return classes.join(' ')
   }
+
+  const checkDisabled = isTextInput ? textInputValue.trim() === '' : selectedAnswer === null
 
   if (showResult) {
     return (
@@ -258,26 +279,68 @@ function QuizView({ mod, lesson, onComplete, onBack }) {
     <div className="quiz-container">
       <button className="back-button" onClick={onBack}>← Back to Lessons</button>
       <div className="quiz-header">
-        <div className="quiz-title">{lesson.isRevision ? '🔄 ' : ''}{lesson.title}</div>
+        <div className="quiz-title">
+          {lesson.isRevision ? '🔄 ' : lesson.isCaseStudy ? '📋 ' : ''}{lesson.title}
+        </div>
         <div className="quiz-progress">
           Question {questionIndex + 1} of {questionQueue.length}
           {roundNumber > 1 && <span className="retry-badge">Retry Round {roundNumber}</span>}
         </div>
       </div>
-      <div className="question-card">
-        <div className="question-text">{question.question}</div>
-        <div className="answers">
-          {question.answers.map((answer, index) => (
-            <button
-              key={index}
-              className={getAnswerClass(index)}
-              onClick={() => handleSelectAnswer(index)}
-              disabled={answered}
-            >
-              {answer}
-            </button>
-          ))}
+
+      {lesson.isCaseStudy && (
+        <div className="scenario-card">
+          <button
+            className="scenario-toggle"
+            onClick={() => setScenarioCollapsed(c => !c)}
+          >
+            📋 Scenario {scenarioCollapsed ? '▶ Show' : '▼ Hide'}
+          </button>
+          {!scenarioCollapsed && (
+            <div className="scenario-text">{lesson.scenario}</div>
+          )}
         </div>
+      )}
+
+      <div className="question-card">
+        {isTextInput && (
+          <div className="question-type-badge">✏️ Type your answer</div>
+        )}
+        <div className="question-text">{question.question}</div>
+
+        {isTextInput ? (
+          <div className="text-input-container">
+            <input
+              type="text"
+              className={`text-answer-input${answered ? (isTextCorrect ? ' correct' : ' incorrect') : ''}`}
+              value={textInputValue}
+              onChange={e => setTextInputValue(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && !answered && !checkDisabled && handleCheckAnswer()}
+              placeholder="Type your answer here…"
+              disabled={answered}
+              autoFocus
+            />
+            {answered && !isTextCorrect && (
+              <div className="text-correct-answer">
+                ✓ Accepted: {question.acceptedAnswers[0]}
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="answers">
+            {question.answers.map((answer, index) => (
+              <button
+                key={index}
+                className={getAnswerClass(index)}
+                onClick={() => handleSelectAnswer(index)}
+                disabled={answered}
+              >
+                {answer}
+              </button>
+            ))}
+          </div>
+        )}
+
         {answered && (
           <div className="explanation">
             <div className="explanation-title">💡 Explanation</div>
@@ -290,7 +353,7 @@ function QuizView({ mod, lesson, onComplete, onBack }) {
           <button
             className="btn btn-primary"
             onClick={handleCheckAnswer}
-            disabled={selectedAnswer === null}
+            disabled={checkDisabled}
           >
             Check Answer
           </button>

--- a/src/modules/module1.js
+++ b/src/modules/module1.js
@@ -356,6 +356,71 @@ export default {
           correct: 1,
           explanation: "Azure Log Analytics stores diagnostic log data and supports KQL queries for deep analysis. You can filter, group, sort, and aggregate log records to find patterns like the slowest requests, authentication failures, or high-latency calls."
         }
+      ],
+      variantQuestions: [
+        {
+          type: 'text-input',
+          question: "What is the name of the Azure query language used to analyse logs in Log Analytics? (abbreviation is fine)",
+          acceptedAnswers: ["KQL", "Kusto Query Language", "kusto query language", "kql"],
+          explanation: "Kusto Query Language (KQL) is the query language used in Azure Log Analytics and Azure Monitor to search, filter, and aggregate log and metric data."
+        }
+      ]
+    },
+    {
+      title: "Case Study: Contoso Insurance Modernisation",
+      isCaseStudy: true,
+      scenario: `Contoso Insurance wants to modernise three internal processes:
+
+1. Invoice processing — the accounts team manually keys data from thousands of supplier invoices monthly.
+2. Customer helpdesk — support agents spend most of their day answering the same policy FAQ questions.
+3. Security posture — a recent audit found API keys hard-coded in application configuration files.
+
+They have selected Azure AI services and need to choose the right service for each need, then apply security best practices.`,
+      questions: [
+        {
+          question: "Contoso wants to automatically extract vendor names, invoice dates, and totals from supplier invoices without custom model training. Which Azure service should they use?",
+          answers: [
+            "Azure AI Vision — image analysis",
+            "Azure Document Intelligence with the prebuilt-invoice model",
+            "Azure AI Search with a custom skillset",
+            "Azure AI Language — key phrase extraction"
+          ],
+          correct: 1,
+          explanation: "Azure Document Intelligence includes prebuilt models (e.g., prebuilt-invoice) that extract structured fields such as vendor, date, amounts, and line items from invoices without requiring custom training."
+        },
+        {
+          question: "Contoso wants to automate answers to common policy questions using a Q&A knowledge base built from existing FAQ documents. Which Azure AI Language feature is designed for this?",
+          answers: [
+            "Custom named entity recognition (NER)",
+            "Sentiment analysis",
+            "Custom question answering",
+            "Text classification"
+          ],
+          correct: 2,
+          explanation: "Azure AI Language's custom question answering feature lets you build a knowledge base from FAQ documents or URLs, then query it to return the best matching answer — ideal for helpdesk automation."
+        },
+        {
+          question: "The security audit found API keys stored in application config files. What is the recommended fix to authenticate to Azure AI services without storing any credentials?",
+          answers: [
+            "Encrypt the keys with Base64 before storing them",
+            "Store the keys in Azure Key Vault and retrieve them at runtime",
+            "Assign a managed identity to the application and grant it the Cognitive Services User role",
+            "Rotate the keys automatically every 24 hours"
+          ],
+          correct: 2,
+          explanation: "Managed identities provide credential-free authentication. The application holds no secret — Azure AD manages the identity token automatically, and Azure AI services accept it via role-based access control."
+        },
+        {
+          question: "Contoso's operations team wants to be alerted when the invoice-processing API returns more than 20 errors in a 5-minute window. Which Azure capability should they configure?",
+          answers: [
+            "Azure Cost Management budget alert",
+            "Azure Monitor metric alert rule on the AI service resource",
+            "Azure Advisor recommendation policy",
+            "Microsoft Defender for Cloud security alert"
+          ],
+          correct: 1,
+          explanation: "Azure Monitor metric alerts watch a specific metric (such as failed call count) on an Azure resource and trigger notifications when thresholds are breached within a time window."
+        }
       ]
     }
   ]

--- a/src/modules/module2.js
+++ b/src/modules/module2.js
@@ -272,6 +272,70 @@ export default {
           correct: 2,
           explanation: "A low groundedness score indicates the model is generating content not found in the retrieved documents — a hallucination. Groundedness is the key metric to monitor in RAG systems."
         }
+      ],
+      variantQuestions: [
+        {
+          type: 'text-input',
+          question: "What is the name of the Azure AI Foundry evaluation metric that measures whether a model's answer is supported by the retrieved context documents?",
+          acceptedAnswers: ["groundedness", "Groundedness"],
+          explanation: "Groundedness measures how well the model's response is supported by the retrieved context. A low score indicates the model is hallucinating content not found in the source documents."
+        }
+      ]
+    },
+    {
+      title: "Case Study: Fabrikam Customer Support Chatbot",
+      isCaseStudy: true,
+      scenario: `Fabrikam manufactures industrial equipment and wants to build a customer support chatbot on Azure OpenAI. Their requirements are:
+
+1. Knowledge base grounding — the chatbot must answer only from Fabrikam's product manuals; it must not invent answers.
+2. Brand voice — responses must always use Fabrikam's formal engineering tone and specific product abbreviations.
+3. Image queries — technicians should be able to upload a photo of a fault code display and ask for help.
+4. Quality assurance — the team needs to detect when chatbot responses contain information not found in any manual.`,
+      questions: [
+        {
+          question: "Fabrikam needs the chatbot to answer only from their product manuals without retraining the model. Which architectural pattern achieves this?",
+          answers: [
+            "Fine-tune GPT-4o on all product manuals",
+            "Implement Retrieval-Augmented Generation (RAG) to inject relevant manual excerpts into each prompt",
+            "Include all manuals in the system message of every API call",
+            "Use a lower temperature to prevent the model from inventing answers"
+          ],
+          correct: 1,
+          explanation: "RAG retrieves the most relevant manual sections at query time and injects them as context. This grounds responses in Fabrikam's documents without retraining, and stays up-to-date as manuals change."
+        },
+        {
+          question: "Fabrikam wants every chatbot response to use their formal engineering tone and product abbreviations without adding a lengthy style guide to every prompt. What is the most efficient approach?",
+          answers: [
+            "Add the full style guide to the system message in every API call",
+            "Fine-tune the Azure OpenAI model on examples written in the brand voice",
+            "Set temperature=0 to make responses more formal",
+            "Use chain-of-thought prompting to improve response quality"
+          ],
+          correct: 1,
+          explanation: "Fine-tuning bakes consistent style, tone, and vocabulary into the model weights. This is ideal when a system-message style guide would be too verbose or still produce inconsistent results across varied queries."
+        },
+        {
+          question: "A technician uploads a photo of a fault code display and types 'What does this mean?'. Which Azure OpenAI capability allows the chatbot to process both the image and the text together?",
+          answers: [
+            "GPT-4o cannot process images; use Azure AI Vision first and pass the description",
+            "GPT-4o's large multimodal model (LMM) capability accepts both text and image inputs in a single API call",
+            "Use DALL-E to interpret the fault code image",
+            "Submit the image to Azure Document Intelligence to extract the code, then pass it to GPT-4"
+          ],
+          correct: 1,
+          explanation: "GPT-4o and other large multimodal models (LMMs) in Azure OpenAI natively accept both text and image inputs in a single API call, removing the need for a separate image preprocessing step."
+        },
+        {
+          question: "After launch, QA testers find that some chatbot answers contain technical details not present in any product manual. Which Azure AI Foundry evaluation metric should the team monitor to detect this?",
+          answers: [
+            "Fluency — to check grammatical correctness",
+            "Coherence — to check logical sentence flow",
+            "Groundedness — to check whether responses are supported by retrieved context",
+            "Similarity — to compare responses to reference answers"
+          ],
+          correct: 2,
+          explanation: "Groundedness measures whether the model's response is supported by the retrieved context. A low score indicates hallucination — content invented by the model rather than sourced from the retrieved manuals."
+        }
       ]
     }
   ]

--- a/src/modules/module3.js
+++ b/src/modules/module3.js
@@ -115,6 +115,70 @@ export default {
           correct: 1,
           explanation: "A planner is the reasoning component in agent frameworks like Semantic Kernel. Given a goal, it uses the LLM to create a dynamic plan — choosing which tools (plugins) to invoke and in which order — rather than following a fixed workflow."
         }
+      ],
+      variantQuestions: [
+        {
+          type: 'text-input',
+          question: "In the Microsoft Foundry Agent Service, which built-in tool allows an agent to write and run Python code in a sandboxed environment?",
+          acceptedAnswers: ["code interpreter", "Code Interpreter", "code interpreter tool", "Code Interpreter tool"],
+          explanation: "The Code Interpreter tool gives a Foundry Agent a sandboxed Python execution environment. It can read uploaded files, run calculations, generate charts, and return results without any external infrastructure."
+        }
+      ]
+    },
+    {
+      title: "Case Study: AdventureWorks Travel Booking Agent",
+      isCaseStudy: true,
+      scenario: `AdventureWorks Holidays wants to build an AI travel assistant on Azure that can:
+
+1. Itinerary planning — take a customer's destination and dates, search live flight and hotel availability, and produce a complete itinerary.
+2. Data analysis — process uploaded trip-cost CSV files and summarise total spend per category.
+3. Delegation — for complex group bookings, hand off accommodation research to a specialist agent while the main agent handles flights.
+4. Autonomy — complete these tasks without a human approving each step, but let a human review before any payment is charged.`,
+      questions: [
+        {
+          question: "The travel assistant needs to search flight APIs and hotel databases, maintain conversation context across turns, and produce a final itinerary. A single chat completion cannot do this. What should AdventureWorks build?",
+          answers: [
+            "A fine-tuned GPT-4 model trained on travel data",
+            "An AI agent that can autonomously call tools (flight search API, hotel API) and plan multi-step tasks",
+            "A RAG pipeline that retrieves travel information from a static document store",
+            "A prompt chain where each API call is made manually by the application"
+          ],
+          correct: 1,
+          explanation: "An AI agent uses an LLM as its reasoning engine but adds the ability to call tools (APIs), maintain state across steps, and plan sequences of actions autonomously — exactly what's needed for dynamic itinerary building."
+        },
+        {
+          question: "A customer uploads a CSV of trip expenses and wants a summary of spend by category. Which Foundry Agent tool should be enabled to process the file with Python?",
+          answers: [
+            "File search tool — to retrieve text from the uploaded document",
+            "Code interpreter tool — to execute Python code that reads and analyses the CSV",
+            "Function calling with an external analytics API",
+            "Custom content safety filter for financial data"
+          ],
+          correct: 1,
+          explanation: "The code interpreter tool provides a sandboxed Python environment where the agent can read the uploaded CSV, run Pandas or similar analysis, and return a structured summary — all without external infrastructure."
+        },
+        {
+          question: "For large group bookings, AdventureWorks wants one main agent to handle flights while delegating hotel research to a specialist agent. What architectural pattern is this?",
+          answers: [
+            "Single-agent RAG with multiple vector stores",
+            "Multi-agent orchestration — an orchestrator delegates subtasks to specialist worker agents",
+            "Prompt chaining — sequential API calls managed by application code",
+            "Federated fine-tuning across regional model deployments"
+          ],
+          correct: 1,
+          explanation: "Multi-agent orchestration uses a top-level orchestrator to decompose a goal and delegate subtasks to specialist workers. The orchestrator synthesises results from all workers to produce the final response."
+        },
+        {
+          question: "AdventureWorks wants the agent to act autonomously for planning but pause for human approval before processing any payment. What design principle does this represent?",
+          answers: [
+            "Removing the agent's tool access for payment functions",
+            "Human-in-the-loop — a checkpoint where the agent pauses and requires human confirmation before irreversible actions",
+            "Setting temperature=0 to make payment decisions deterministic",
+            "Using content safety filters to block payment-related prompts"
+          ],
+          correct: 1,
+          explanation: "Human-in-the-loop (HITL) is a design pattern where an autonomous agent pauses at defined checkpoints — typically before irreversible actions like payments — and waits for a human to review and approve before proceeding."
+        }
       ]
     }
   ]

--- a/src/modules/module4.js
+++ b/src/modules/module4.js
@@ -272,6 +272,58 @@ export default {
           correct: 1,
           explanation: "Video insights are retrieved via the Video Indexer REST API (GET /Videos/{videoId}/Index). The response is a comprehensive JSON object containing all extracted metadata including speakers, topics, transcripts, and sentiment."
         }
+      ],
+      variantQuestions: [
+        {
+          type: 'text-input',
+          question: "Which Azure AI service is purpose-built to extract insights (transcripts, topics, speaker identification) from uploaded video files, with no custom training required?",
+          acceptedAnswers: ["Azure AI Video Indexer", "Video Indexer", "Azure Video Indexer"],
+          explanation: "Azure AI Video Indexer provides comprehensive, built-in video intelligence including speech-to-text, speaker diarization, topic detection, face identification, and keyframe extraction — all out of the box."
+        }
+      ]
+    },
+    {
+      title: "Case Study: Northwind Retail Vision Platform",
+      isCaseStudy: true,
+      scenario: `Northwind Retail is building a computer vision platform across their stores and distribution centres. They have three distinct requirements:
+
+1. Shelf monitoring — automatically identify which products are on a shelf from photo uploads, using a custom model trained on their own product catalogue.
+2. Access control — verify that a face captured at a turnstile belongs to an authorised employee, and prevent access attempts using a printed photo.
+3. Store footfall — count the number of people in each checkout zone in real time from live CCTV feeds.`,
+      questions: [
+        {
+          question: "Northwind wants to classify product images into their own catalogue categories. No suitable prebuilt Azure model exists for their products. Which Azure service should they use?",
+          answers: [
+            "Azure AI Vision image analysis with the Tags visual feature",
+            "Azure AI Custom Vision — train a custom classification model on labelled product images",
+            "Azure AI Document Intelligence for product label extraction",
+            "Azure OpenAI GPT-4o with few-shot product examples in the prompt"
+          ],
+          correct: 1,
+          explanation: "Azure AI Custom Vision lets you train a classification model on your own labelled images. When no prebuilt model covers your categories, Custom Vision is the correct choice for domain-specific image classification."
+        },
+        {
+          question: "At the distribution centre turnstile, a security guard notices someone holding up a printed photo to the camera. Which Azure AI Face capability would detect and block this presentation attack?",
+          answers: [
+            "Increasing the identification confidence threshold to 0.95",
+            "Liveness detection — determines whether the face is from a real live person or a presentation attack",
+            "Face verification comparing the photo against the enrolled employee record",
+            "returnFaceAttributes with blur detection to reject low-quality images"
+          ],
+          correct: 1,
+          explanation: "Liveness detection verifies that the face comes from a physically present live person, not a photograph or video replay. No confidence threshold or quality filter can substitute for this anti-spoofing check."
+        },
+        {
+          question: "The store operations team needs to know in real time how many people are in each checkout zone from live CCTV. Which Azure AI Vision capability is purpose-built for this use case?",
+          answers: [
+            "Custom Vision object detection model triggered on captured frames",
+            "Image Analysis batch processing running every 30 seconds",
+            "Spatial Analysis — real-time people detection and zone occupancy in live video streams",
+            "Azure AI Video Indexer for post-recording crowd analysis"
+          ],
+          correct: 2,
+          explanation: "Spatial Analysis is designed for real-time people detection and movement tracking in live video streams, including zone-based occupancy counting. Unlike batch or post-hoc tools, it operates continuously on live feeds."
+        }
       ]
     }
   ]

--- a/src/modules/module5.js
+++ b/src/modules/module5.js
@@ -334,6 +334,69 @@ export default {
           correct: 1,
           explanation: "Azure AI Language custom question answering supports multi-language projects. Content can be stored in multiple languages, and the service automatically detects the query language and matches it to the appropriate content — no separate projects required."
         }
+      ],
+      variantQuestions: [
+        {
+          type: 'text-input',
+          question: "What is the name of the XML-based markup language used to control Azure AI Speech synthesis, including pauses, pronunciation, and prosody?",
+          acceptedAnswers: ["SSML", "ssml", "Speech Synthesis Markup Language", "speech synthesis markup language"],
+          explanation: "SSML (Speech Synthesis Markup Language) is an XML-based standard that provides fine-grained control over text-to-speech output, including prosody, pauses, phoneme pronunciation, and voice selection."
+        }
+      ]
+    },
+    {
+      title: "Case Study: Tailwind Traders Global Support Hub",
+      isCaseStudy: true,
+      scenario: `Tailwind Traders operates a global customer support hub serving customers in English, German, French, and Spanish. They are building an NLP platform with three workstreams:
+
+1. Call transcription — live calls need to be transcribed with high accuracy, including Tailwind's proprietary product codes (e.g., TW-X400, TW-PRO).
+2. Document translation — Tailwind's 500-page product manual must be translated into all four supported languages while preserving its table-of-contents and formatting.
+3. Complaint handling — customer complaint emails need to be summarised into concise paragraphs (not direct quotes), then checked for PII before being stored.`,
+      questions: [
+        {
+          question: "The base Azure AI Speech model frequently misrecognises Tailwind's product codes during live calls. What should the team implement to improve accuracy?",
+          answers: [
+            "Switch from real-time to batch transcription mode",
+            "Train a custom speech model on Tailwind's own call recordings and transcripts",
+            "Use pronunciation assessment to flag uncertain recognitions",
+            "Increase the audio sample rate from 16 kHz to 48 kHz"
+          ],
+          correct: 1,
+          explanation: "Custom speech allows you to train a model on domain-specific audio and transcripts, adapting it to recognise specialised vocabulary and product codes that the base model handles poorly."
+        },
+        {
+          question: "Tailwind needs to translate their 500-page product manual into four languages while keeping tables, headers, and images in place. Which Azure AI Translator feature should they use?",
+          answers: [
+            "Standard text translation with textType=html",
+            "Document translation — processes full documents asynchronously and preserves formatting",
+            "Custom Translator trained on product manual terminology",
+            "Batch text translation via the Language Studio"
+          ],
+          correct: 1,
+          explanation: "Document translation processes complete documents (Word, PDF, HTML) and preserves original layout, tables, and formatting while translating content. Standard text translation strips formatting and requires manual reconstruction."
+        },
+        {
+          question: "A data team wants to summarise customer complaint emails into concise prose — not direct quotes — before storing them. Which Azure AI Language feature should they use?",
+          answers: [
+            "Extractive summarization — selects and returns key sentences verbatim from the email",
+            "Abstractive summarization — generates new, synthesised summary sentences in its own words",
+            "Key phrase extraction — returns important terms and phrases from the email",
+            "Sentiment analysis — classifies the overall tone of the email"
+          ],
+          correct: 1,
+          explanation: "Abstractive summarization generates new summary sentences in the model's own words, synthesising the key information. Extractive summarization returns verbatim sentences — not suitable when paraphrased summaries are required."
+        },
+        {
+          question: "Before storing the summarised complaints, the team must remove any customer names, email addresses, and phone numbers. Which Azure AI Language feature automates this?",
+          answers: [
+            "Key phrase extraction — identifies important terms for removal",
+            "Named entity recognition (NER) — categorises entity mentions",
+            "PII detection and redaction — identifies and removes personal data",
+            "Entity linking — links entities to knowledge base references"
+          ],
+          correct: 2,
+          explanation: "PII detection identifies personal information such as names, phone numbers, email addresses, and IDs, and can optionally replace them with placeholders. It is the purpose-built tool for this anonymisation use case."
+        }
       ]
     }
   ]

--- a/src/modules/module6.js
+++ b/src/modules/module6.js
@@ -210,6 +210,58 @@ export default {
           correct: 1,
           explanation: "The Azure Content Understanding ingestion pipeline extracts multiple element types — entities, tables, and embedded images — from documents in a single pass. This avoids the need to chain separate OCR, NER, and image extraction tools."
         }
+      ],
+      variantQuestions: [
+        {
+          type: 'text-input',
+          question: "In Azure AI Search, what is the name of the feature that persists AI-enriched content from the skillset pipeline into Azure Storage as tables, objects, or files for downstream analytics?",
+          acceptedAnswers: ["Knowledge Store", "knowledge store", "the knowledge store", "The Knowledge Store"],
+          explanation: "The Knowledge Store persists enriched content produced by the skillset pipeline as projections in Azure Storage — as tables, JSON objects, or files — making it independently consumable by analytics tools and ML pipelines."
+        }
+      ]
+    },
+    {
+      title: "Case Study: Woodgrove Bank Document Intelligence",
+      isCaseStudy: true,
+      scenario: `Woodgrove Bank processes thousands of documents daily across three departments:
+
+1. Accounts payable — hundreds of supplier invoices from different vendors arrive every day and need key fields (vendor, date, total) extracted automatically.
+2. Legal — contract PDFs must be made searchable with AI-enriched metadata (entities, key phrases, sentiment), and the enriched data must also be available to a separate analytics dashboard.
+3. Compliance — a new regulation requires all stored documents to be searchable by semantic meaning, not just keywords.`,
+      questions: [
+        {
+          question: "Woodgrove receives invoices from 50 different suppliers, each with a different layout. Which single Document Intelligence approach handles all layouts without building separate models for each?",
+          answers: [
+            "Use prebuilt-read on all invoices and parse the plain text output",
+            "Train one custom model on all 50 invoice layouts mixed together",
+            "Use prebuilt-invoice, which automatically handles all invoice layouts",
+            "Build a composed model combining custom models for each supplier under one model ID"
+          ],
+          correct: 3,
+          explanation: "A composed model aggregates multiple custom models — each trained for a specific layout — under a single model ID. The service routes each document to the best-matching component model, enabling one API call to handle all supplier formats."
+        },
+        {
+          question: "The legal team wants to index contract PDFs with AI-extracted entities and key phrases AND make those enriched results available to a Power BI dashboard independently of the search index. Which Azure AI Search feature supports the second requirement?",
+          answers: [
+            "A custom skill that posts enriched data to an external API",
+            "The Knowledge Store, which persists skillset enrichments as tables or JSON in Azure Storage",
+            "An additional indexer that exports the search index to Azure Blob Storage",
+            "Azure AI Language post-processing applied after indexing"
+          ],
+          correct: 1,
+          explanation: "The Knowledge Store persists AI-enriched content from the skillset pipeline into Azure Storage as tables, objects, or files. This makes enriched data independently consumable by downstream analytics tools without going through the search index."
+        },
+        {
+          question: "Compliance requires that lawyers can find contracts containing the concept of 'force majeure' even if a document uses different wording such as 'act of God' or 'unforeseen circumstances'. Which Azure AI Search feature enables this conceptual retrieval?",
+          answers: [
+            "OData $filter expressions on a keywords field",
+            "Lucene full-text query syntax with synonym maps",
+            "Semantic ranking, which re-ranks results by conceptual relevance using language models",
+            "BM25 keyword scoring with boosting on the content field"
+          ],
+          correct: 2,
+          explanation: "Semantic ranking uses language models to understand the meaning of queries and re-rank results by conceptual relevance, not just keyword frequency. This enables conceptual search where different phrasing of the same idea returns relevant results."
+        }
       ]
     }
   ]


### PR DESCRIPTION
Closes #11

Adds two new revision/question formats across all six modules:

1. **Text-input questions** — users type an answer matched case-insensitively against accepted answers.
2. **Case study lessons** — each module gets a short scenario + 3–4 questions; completing one covers the entire lesson slot.

Generated with [Claude Code](https://claude.ai/code)